### PR TITLE
Add Docker configuration and CLI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+ENTRYPOINT ["python", "-m", "insight"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
 # InsightPress
+
+This project contains a placeholder CLI that simulates generating reports from a dataset.
+
+## Docker Usage
+
+1. **Build the image**
+
+```bash
+docker build -t insightpress .
+```
+
+2. **Prepare data**
+
+Place your input file inside a `data/` directory relative to the repository. The compose file expects `input.csv` in this folder and writes results to `data/report`.
+
+3. **Run the container**
+
+```bash
+docker-compose run --rm app
+```
+
+The command mounts the local `data/` folder inside the container at `/data`. Adjust the `command` in `docker-compose.yml` if your input or output paths differ.
+
+You can also run the image directly:
+
+```bash
+docker run --rm -v $(pwd)/data:/data insightpress python -m insight /data/input.csv /data/report
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+version: '3'
+services:
+  app:
+    build: .
+    volumes:
+      - ./data:/data
+    command: python -m insight /data/input.csv /data/report

--- a/insight/__main__.py
+++ b/insight/__main__.py
@@ -1,0 +1,4 @@
+from .cli import main
+
+if __name__ == "__main__":
+    main()

--- a/insight/cli.py
+++ b/insight/cli.py
@@ -1,0 +1,15 @@
+import argparse
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate insights from data")
+    parser.add_argument("input", help="Path to input CSV file")
+    parser.add_argument("output", help="Directory where the report will be saved")
+    args = parser.parse_args()
+
+    # Placeholder processing logic
+    print(f"Processing {args.input} and saving report to {args.output}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- create simple CLI and __main__ entry
- add Dockerfile to install dependencies and run the CLI
- provide docker-compose.yml with mounted data path
- document Docker workflow in README

## Testing
- `python -m py_compile insight/cli.py insight/__main__.py`
- `python -m insight.cli -h`
- `docker build -t testimage .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684de9beead48323a697bcf0c41413a3