### PR TITLE
Add basic modules, tests, and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      - name: Run tests
+        run: |
+          pytest -v

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.venv/
+__pycache__/
+*.pyc
+.python-version

--- a/insight/chart_planner.py
+++ b/insight/chart_planner.py
@@ -1,0 +1,11 @@
+import pandas as pd
+import matplotlib.pyplot as plt
+
+
+def line_chart(df: pd.DataFrame, x: str, y: str):
+    """Return a matplotlib Figure with a simple line plot."""
+    fig, ax = plt.subplots()
+    ax.plot(df[x], df[y])
+    ax.set_xlabel(x)
+    ax.set_ylabel(y)
+    return fig

--- a/insight/forecaster.py
+++ b/insight/forecaster.py
@@ -1,0 +1,10 @@
+import numpy as np
+import pandas as pd
+
+
+def simple_forecast(series: pd.Series, steps: int = 1) -> np.ndarray:
+    """Generate a naive linear forecast for the given series."""
+    idx = np.arange(len(series))
+    coeffs = np.polyfit(idx, series.values, 1)
+    last_idx = len(series) - 1
+    return np.array([coeffs[0] * (last_idx + i + 1) + coeffs[1] for i in range(steps)])

--- a/insight/insight_writer.py
+++ b/insight/insight_writer.py
@@ -1,0 +1,8 @@
+import pandas as pd
+
+
+def narrative(df: pd.DataFrame, column: str) -> str:
+    """Generate a simple narrative text for the given column."""
+    mean = df[column].mean()
+    median = df[column].median()
+    return f"The average {column} is {mean:.2f} and the median is {median:.2f}."

--- a/insight/profiler.py
+++ b/insight/profiler.py
@@ -1,0 +1,7 @@
+import pandas as pd
+
+
+def basic_profile(df: pd.DataFrame) -> dict:
+    """Return basic descriptive statistics for the given DataFrame."""
+    desc = df.describe(include='all')
+    return desc.to_dict()

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -1,0 +1,34 @@
+import sys, os
+venv_path=os.path.join(os.path.dirname(os.path.dirname(__file__)),'.venv','lib','python3.11','site-packages')
+if os.path.exists(venv_path):
+    sys.path.insert(0, venv_path)
+import pandas as pd
+import matplotlib.figure
+from insight import profiler, chart_planner, forecaster, insight_writer
+
+
+def test_basic_profiling_output():
+    df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+    profile = profiler.basic_profile(df)
+    assert "a" in profile
+    assert profile["a"]["mean"] == 2.0
+
+
+def test_chart_generation_returns_matplotlib_object():
+    df = pd.DataFrame({"x": [1, 2, 3], "y": [2, 4, 6]})
+    fig = chart_planner.line_chart(df, "x", "y")
+    assert isinstance(fig, matplotlib.figure.Figure)
+
+
+def test_forecasting_produces_numeric_predictions():
+    series = pd.Series([1, 2, 3, 4, 5])
+    preds = forecaster.simple_forecast(series, steps=2)
+    assert len(preds) == 2
+    assert all(isinstance(v, (int, float)) for v in preds)
+
+
+def test_narrative_includes_statistics():
+    df = pd.DataFrame({"value": [1, 3, 5]})
+    text = insight_writer.narrative(df, "value")
+    assert "average value is" in text
+    assert "median is" in text


### PR DESCRIPTION
## Summary
- implement simple profiling, charting, forecasting and narrative utilities
- create pytest-based tests covering these utilities
- add GitHub Actions workflow running the tests
- ignore virtualenv artifacts

## Testing
- `pytest -q` *(fails: ImportError: Unable to import required dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684de9c26c7483238d5b23750596057c