### PR TITLE
Add placeholder tests

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,27 @@
+import subprocess
+from pathlib import Path
+
+
+def test_cli_invalid_path():
+    result = subprocess.run(
+        ["insightpress", "run", "nofile.csv"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    assert result.returncode == 1
+
+
+def test_cli_happy_path(tmp_path: Path):
+    csv_file = tmp_path / "input.csv"
+    csv_file.write_text("a,b\n1,2\n")
+
+    result = subprocess.run(
+        ["insightpress", "run", str(csv_file)],
+        cwd=tmp_path,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert (tmp_path / "report.pdf").exists()

--- a/tests/test_composer.py
+++ b/tests/test_composer.py
@@ -1,0 +1,6 @@
+import importlib
+
+
+def test_pdf_composer_importable():
+    module = importlib.import_module("insight.pdf_composer")
+    assert hasattr(module, "__file__")


### PR DESCRIPTION
## Summary
- add placeholder CLI tests checking exit codes
- add trivial composer import test

## Testing
- `pytest -q` *(fails: FileNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_684dea72dd4c8323939711ea27022389