### PR TITLE
Integrate structlog logging

### DIFF
--- a/insight/__init__.py
+++ b/insight/__init__.py
@@ -1,0 +1,10 @@
+"""InsightPress package."""
+
+from .logger import configure_logging, log
+from .pipeline import run_pipeline
+
+__all__ = [
+    "configure_logging",
+    "log",
+    "run_pipeline",
+]

--- a/insight/chart_planner.py
+++ b/insight/chart_planner.py
@@ -1,0 +1,5 @@
+"""chart_planner stage."""
+
+def run(data=None):
+    """Placeholder stage."""
+    return []

--- a/insight/cli.py
+++ b/insight/cli.py
@@ -1,0 +1,11 @@
+from .logger import configure_logging
+from .pipeline import run_pipeline
+
+
+def main() -> None:
+    configure_logging()
+    run_pipeline()
+
+
+if __name__ == "__main__":
+    main()

--- a/insight/forecaster.py
+++ b/insight/forecaster.py
@@ -1,0 +1,5 @@
+"""forecaster stage."""
+
+def run(data=None):
+    """Placeholder stage."""
+    return []

--- a/insight/insight_writer.py
+++ b/insight/insight_writer.py
@@ -1,0 +1,5 @@
+"""insight_writer stage."""
+
+def run(data=None):
+    """Placeholder stage."""
+    return []

--- a/insight/logger.py
+++ b/insight/logger.py
@@ -1,0 +1,37 @@
+import logging
+import sys
+
+import structlog
+
+
+def configure_logging():
+    """Configure structlog with JSON or rich renderer."""
+    timestamper = structlog.processors.TimeStamper(fmt="iso")
+    shared_processors = [
+        structlog.processors.add_log_level,
+        timestamper,
+    ]
+
+    if sys.stderr.isatty():
+        try:
+            from structlog.rich import RichRenderer
+
+            renderer = RichRenderer()
+        except Exception:  # pragma: no cover - fallback for older structlog
+            from structlog.dev import ConsoleRenderer
+
+            renderer = ConsoleRenderer()
+    else:
+        renderer = structlog.processors.JSONRenderer()
+
+    structlog.configure(
+        processors=shared_processors + [renderer],
+        wrapper_class=structlog.make_filtering_bound_logger(logging.INFO),
+        logger_factory=structlog.PrintLoggerFactory(),
+        cache_logger_on_first_use=True,
+    )
+
+    logging.basicConfig(format="%(message)s", level=logging.INFO)
+
+
+log = structlog.get_logger()

--- a/insight/pdf_composer.py
+++ b/insight/pdf_composer.py
@@ -1,0 +1,5 @@
+"""pdf_composer stage."""
+
+def run(data=None):
+    """Placeholder stage."""
+    return []

--- a/insight/pipeline.py
+++ b/insight/pipeline.py
@@ -1,0 +1,34 @@
+import time
+
+from .logger import log
+from .profiler import run as run_profiler
+from .forecaster import run as run_forecaster
+from .chart_planner import run as run_chart_planner
+from .visual_builder import run as run_visual_builder
+from .insight_writer import run as run_insight_writer
+from .pdf_composer import run as run_pdf_composer
+
+
+STAGES = [
+    ("profiler", run_profiler),
+    ("forecaster", run_forecaster),
+    ("chart_planner", run_chart_planner),
+    ("visual_builder", run_visual_builder),
+    ("insight_writer", run_insight_writer),
+    ("pdf_composer", run_pdf_composer),
+]
+
+
+def run_pipeline(data=None):
+    """Run all stages and log their completion."""
+    for name, stage_fn in STAGES:
+        start = time.perf_counter()
+        artefacts = stage_fn(data)
+        duration = (time.perf_counter() - start) * 1000
+        artefact_count = len(artefacts) if artefacts is not None else 0
+        log.info(
+            "stage_done",
+            stage_name=name,
+            duration_ms=int(duration),
+            artefacts_count=artefact_count,
+        )

--- a/insight/profiler.py
+++ b/insight/profiler.py
@@ -1,0 +1,5 @@
+"""profiler stage."""
+
+def run(data=None):
+    """Placeholder stage."""
+    return []

--- a/insight/visual_builder.py
+++ b/insight/visual_builder.py
@@ -1,0 +1,5 @@
+"""visual_builder stage."""
+
+def run(data=None):
+    """Placeholder stage."""
+    return []

--- a/requirements.txt
+++ b/requirements.txt
@@ -48,3 +48,4 @@ urllib3==2.4.0
 visions==0.8.1
 wordcloud==1.9.4
 ydata-profiling==4.16.1
+structlog==24.1.0


### PR DESCRIPTION
## Summary
- add structlog configuration with optional rich console output
- implement a pipeline runner that logs each stage
- stub stage modules for profiler, forecaster, chart planner, etc
- create CLI entrypoint
- add structlog to requirements

## Testing
- `python -m compileall insight`

------
https://chatgpt.com/codex/tasks/task_e_684deaa862c083239d92a2bfe9581950