### PR TITLE
Add caching utilities and CLI flag

### DIFF
--- a/insight/cache_utils.py
+++ b/insight/cache_utils.py
@@ -1,0 +1,44 @@
+import functools
+import importlib.metadata
+from joblib import Memory
+
+# Shared joblib cache
+memory = Memory('.cache', verbose=0)
+
+# Packages whose versions we include in the cache key
+DEFAULT_PACKAGES = [
+    'numpy',
+    'pandas',
+    'matplotlib',
+    'seaborn',
+    'scipy',
+    'statsmodels',
+    'joblib',
+]
+
+def _library_versions(packages=DEFAULT_PACKAGES):
+    """Return a tuple of (package, version) for hashing."""
+    versions = []
+    for pkg in packages:
+        try:
+            ver = importlib.metadata.version(pkg)
+        except importlib.metadata.PackageNotFoundError:  # pragma: no cover - optional deps
+            ver = None
+        versions.append((pkg, ver))
+    return tuple(versions)
+
+def cache_with_versions(func):
+    """Wrap function with joblib.Memory cache including library versions."""
+    cached_func = memory.cache(func)
+
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        kwargs['_lib_versions'] = _library_versions()
+        return cached_func(*args, **kwargs)
+
+    return wrapper
+
+
+def clear_cache():
+    """Remove all cached results."""
+    memory.clear(warn=False)

--- a/insight/cli.py
+++ b/insight/cli.py
@@ -1,0 +1,33 @@
+"""Command line interface for InsightPress demo."""
+
+from __future__ import annotations
+
+import argparse
+import pandas as pd
+from . import pipeline
+from . import cache_utils
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="InsightPress demo")
+    parser.add_argument(
+        "--clear-cache",
+        action="store_true",
+        help="Clear cached results and exit",
+    )
+    args = parser.parse_args(argv)
+
+    if args.clear_cache:
+        cache_utils.clear_cache()
+        print("Cache cleared.")
+        return
+
+    df = pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]})
+    pipeline.build_figures(df)
+    pipeline.maybe_forecast(df)
+    narrative = pipeline.write_narrative(df)
+    print(narrative)
+
+
+if __name__ == "__main__":
+    main()

--- a/insight/pipeline.py
+++ b/insight/pipeline.py
@@ -1,0 +1,30 @@
+"""Minimal data pipeline with caching."""
+
+from __future__ import annotations
+
+import pandas as pd
+import matplotlib.pyplot as plt
+from . import cache_utils
+
+
+@cache_utils.cache_with_versions
+def build_figures(df: pd.DataFrame, _lib_versions=None):
+    """Generate simple plot from dataframe."""
+    fig, ax = plt.subplots()
+    if hasattr(df, "plot"):
+        df.plot(ax=ax)
+    ax.set_title("Data plot")
+    return [fig]
+
+
+@cache_utils.cache_with_versions
+def maybe_forecast(df: pd.DataFrame, _lib_versions=None) -> pd.DataFrame:
+    """Placeholder forecasting step returning dataframe unmodified."""
+    # Real implementation would forecast future values
+    return df
+
+
+@cache_utils.cache_with_versions
+def write_narrative(df: pd.DataFrame, _lib_versions=None) -> str:
+    """Return short narrative about dataframe."""
+    return f"Data has {len(df)} rows and {len(df.columns)} columns."


### PR DESCRIPTION
## Summary
- introduce `cache_utils` with joblib `Memory`
- cache `build_figures`, `maybe_forecast`, `write_narrative` using library versions in the key
- add `--clear-cache` flag to CLI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684deaaec6448323b29ec2cebbbc8c1a