### PR TITLE
Add streamlit app and simple pipeline

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,41 @@
+import tempfile
+from pathlib import Path
+
+import streamlit as st
+
+from insight import run_pipeline
+
+st.set_page_config(page_title="InsightPress")
+st.title("InsightPress")
+
+uploaded_file = st.file_uploader("Upload CSV", type=["csv"])
+progress_bar = st.progress(0)
+status_placeholder = st.empty()
+
+if "pdf_bytes" not in st.session_state:
+    st.session_state.pdf_bytes = None
+
+def generate_report(file):
+    with tempfile.TemporaryDirectory() as tmpdir:
+        csv_path = Path(tmpdir) / "input.csv"
+        csv_path.write_bytes(file.getvalue())
+
+        def callback(stage: str, index: int, total: int) -> None:
+            progress_bar.progress(int((index / total) * 100))
+            status_placeholder.write(f"Stage: {stage}")
+
+        pdf_path = run_pipeline(csv_path, Path(tmpdir), progress_callback=callback)
+        st.session_state.pdf_bytes = pdf_path.read_bytes()
+        progress_bar.progress(100)
+        status_placeholder.write("Done")
+
+if uploaded_file is not None and st.button("Generate InsightPress Report"):
+    generate_report(uploaded_file)
+
+if st.session_state.pdf_bytes is not None:
+    st.download_button(
+        label="Download PDF",
+        data=st.session_state.pdf_bytes,
+        file_name="report.pdf",
+        mime="application/pdf",
+    )

--- a/insight/__init__.py
+++ b/insight/__init__.py
@@ -1,0 +1,3 @@
+from .pipeline import run_pipeline
+
+__all__ = ["run_pipeline"]

--- a/insight/pipeline.py
+++ b/insight/pipeline.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Callable, Optional
+
+import pandas as pd
+import matplotlib.pyplot as plt
+from matplotlib.backends.backend_pdf import PdfPages
+
+
+StageCallback = Callable[[str, int, int], None]
+
+
+def run_pipeline(csv_path: Path, output_dir: Path, progress_callback: Optional[StageCallback] = None) -> Path:
+    """Process ``csv_path`` and generate a simple PDF report.
+
+    Parameters
+    ----------
+    csv_path:
+        Path to the input CSV file.
+    output_dir:
+        Directory where the PDF report will be saved.
+    progress_callback:
+        Function invoked after each stage. It receives the stage name,
+        the current stage index (0-based) and the total number of stages.
+
+    Returns
+    -------
+    Path
+        Path to the generated PDF file.
+    """
+    if progress_callback is None:
+        progress_callback = lambda *args, **kwargs: None
+
+    stages = [
+        "load_data",
+        "create_summary",
+        "generate_plot",
+        "write_pdf",
+    ]
+    total = len(stages)
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    pdf_path = output_dir / "report.pdf"
+
+    # Stage 0: load_data
+    progress_callback(stages[0], 0, total)
+    df = pd.read_csv(csv_path)
+
+    # Stage 1: create_summary
+    progress_callback(stages[1], 1, total)
+    summary = df.describe(include="all")
+
+    # Stage 2: generate_plot
+    progress_callback(stages[2], 2, total)
+    fig, ax = plt.subplots(figsize=(8, 4))
+    df.head().plot(ax=ax)
+    plt.tight_layout()
+
+    # Stage 3: write_pdf
+    progress_callback(stages[3], 3, total)
+    with PdfPages(pdf_path) as pdf:
+        # Summary table page
+        fig_summary, ax_summary = plt.subplots(figsize=(8.27, 11.69))
+        ax_summary.axis("off")
+        table = ax_summary.table(
+            cellText=summary.round(2).values,
+            rowLabels=summary.index.tolist(),
+            colLabels=summary.columns.tolist(),
+            loc="center",
+        )
+        table.scale(1, 1.5)
+        pdf.savefig(fig_summary)
+        plt.close(fig_summary)
+
+        # Plot page
+        pdf.savefig(fig)
+        plt.close(fig)
+
+    progress_callback("done", total, total)
+    return pdf_path


### PR DESCRIPTION
## Summary
- implement `run_pipeline` to generate a basic PDF report
- expose `run_pipeline` in the package
- create a Streamlit `app.py` with file upload and progress reporting

## Testing
- `python3 -m py_compile app.py insight/__init__.py insight/pipeline.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684deab6565883238eb9e03734382f0f