### PR TITLE
Add Poetry-based Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+# syntax=docker/dockerfile:1
+
+FROM python:3.11-slim AS builder
+
+# Install build tools and Poetry
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential curl \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl -sSL https://install.python-poetry.org | POETRY_HOME=/opt/poetry python - \
+    && ln -s /opt/poetry/bin/poetry /usr/local/bin/poetry
+
+WORKDIR /app
+
+COPY pyproject.toml poetry.lock* ./
+
+RUN poetry config virtualenvs.in-project true \
+    && poetry install --only main --no-root
+
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY --from=builder /app/.venv /app/.venv
+ENV VIRTUAL_ENV=/app/.venv
+ENV PATH="/app/.venv/bin:$PATH"
+
+COPY . .
+
+EXPOSE 8501
+
+ENTRYPOINT ["insightpress"]


### PR DESCRIPTION
## Summary
- define 2-stage Dockerfile using Python 3.11 slim images
- install Poetry and project dependencies
- copy virtual env and set `VIRTUAL_ENV`
- expose Streamlit port and run `insightpress`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684deabb050483239910b705789e949f